### PR TITLE
GitHub Actionsを使用してCloudflare Workersへの自動デプロイ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy API to Cloudflare Workers
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'api/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.5.1'
+
+      - name: Install dependencies
+        run: |
+          cd api
+          pnpm i
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: 'api'
+          command: deploy --minify

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -2,7 +2,8 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "api",
   "main": "src/index.ts",
-  "compatibility_date": "2025-03-08"
+  "compatibility_date": "2025-03-08",
+  "minify": true
   // "compatibility_flags": [
   //   "nodejs_compat"
   // ],


### PR DESCRIPTION
## ISSUE

close #4 

## 実装概要

mainブランチにマージされたら、/apiの変更内容が自動でCloudflare WorkersへデプロイされるCDを設定しました。

## やらなかったこと

## スクリーンショット

## 影響範囲
